### PR TITLE
Fix add group member bug

### DIFF
--- a/__test__/ui-test/Friend/AddGroupMemberScreen.test.js
+++ b/__test__/ui-test/Friend/AddGroupMemberScreen.test.js
@@ -1,0 +1,52 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import { fireEvent, render } from "@testing-library/react-native";
+import AddGroupMemberScreen from "../../../src/screens/Friend/AddGroupMemberScreen";
+
+const mockSetState = jest.fn();
+const mockGoBack = jest.fn();
+const mockNavigation = {
+  goBack: mockGoBack
+};
+const mockRoute = {
+  params: {
+    groupInfo: {
+      id: "w",
+      name: "Weebs",
+      description: "weebs only",
+      img: "weeb-img"
+    }
+  }
+};
+
+jest.mock("../../../src/services/Friend/FetchGroup");
+jest.mock("../../../src/services/Friend/FetchFriendStatus");
+jest.mock("react", () => ({
+  ...jest.requireActual("react"),
+  useState: (initial) => [initial, mockSetState]
+}));
+
+describe("Test Add Group Member Screen UI", () => {
+  it("Renders correctly", () => {
+    const tree = renderer.create(
+      <AddGroupMemberScreen navigation={mockNavigation} route={mockRoute} />
+    );
+    const instance = tree.root;
+
+    expect(instance.findByProps({ testID: "title" }).props.children).toEqual(
+      "Add Friends to Group"
+    );
+  });
+
+  it("button and search bar is working as expected", () => {
+    const { getByTestId } = render(
+      <AddGroupMemberScreen navigation={mockNavigation} route={mockRoute} />
+    );
+
+    fireEvent.press(getByTestId("goBack"));
+    fireEvent.changeText(getByTestId("searchBar"), "Sugiyem CS Noob");
+
+    expect(mockGoBack).toHaveBeenCalled();
+    expect(mockSetState).toHaveBeenLastCalledWith("Sugiyem CS Noob");
+  });
+});

--- a/__test__/ui-test/Friend/AddMemberComponent.test.js
+++ b/__test__/ui-test/Friend/AddMemberComponent.test.js
@@ -1,0 +1,63 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import { fireEvent, render } from "@testing-library/react-native";
+import AddMemberComponent from "../../../src/components/Friend/AddMemberComponent";
+
+const mockUserData = {
+  id: "yem456",
+  username: "Yemima",
+  bio: "CS Noob",
+  img: "yemima-img",
+  groupRole: "invalid-role"
+};
+const mockCancel = jest.fn();
+const mockInvite = jest.fn();
+
+describe("Test Add Member Tab UI", () => {
+  it("Renders correctly", () => {
+    const tree = renderer.create(<AddMemberComponent item={mockUserData} />);
+    const instance = tree.root;
+
+    expect(instance.findByProps({ testID: "name" }).props.children).toEqual(
+      "Yemima"
+    );
+    expect(instance.findByProps({ testID: "bio" }).props.children).toEqual(
+      "CS Noob"
+    );
+    expect(instance.findByProps({ testID: "role" }).props.children).toEqual(
+      "invalid-role"
+    );
+  });
+
+  it("Invite button works correctly", () => {
+    const { getByTestId, queryByTestId } = render(
+      <AddMemberComponent
+        item={{ ...mockUserData, groupRole: "Not a Member" }}
+        onInvite={mockInvite}
+        onCancel={mockCancel}
+      />
+    );
+
+    // No cancel icon
+    expect(queryByTestId("cancelIcon")).toBeNull();
+
+    fireEvent.press(getByTestId("inviteIcon"));
+    expect(mockInvite).toHaveBeenCalled();
+  });
+
+  it("Cancel button works correctly", () => {
+    const { getByTestId, queryByTestId } = render(
+      <AddMemberComponent
+        item={{ ...mockUserData, groupRole: "Pending Member" }}
+        onInvite={mockInvite}
+        onCancel={mockCancel}
+      />
+    );
+
+    // No invite icon
+    expect(queryByTestId("inviteIcon")).toBeNull();
+
+    fireEvent.press(getByTestId("cancelIcon"));
+    expect(mockCancel).toHaveBeenCalled();
+  });
+});

--- a/src/components/Friend/AddMemberComponent.js
+++ b/src/components/Friend/AddMemberComponent.js
@@ -1,109 +1,66 @@
-import { Alert, StyleSheet } from "react-native";
 import React from "react";
-import { Button, ListItem } from "react-native-elements";
+import styled from "styled-components/native";
+import { Icon, ListItem } from "react-native-elements";
 import ContactImage from "./ContactImage";
-import {
-  addUserToGroup,
-  cancelGroupInvitation,
-  removeUserFromGroup
-} from "../../services/Friend/HandleGroup";
-import { groupMemberType } from "../../constants/Group";
-import Caution from "../Miscellaneous/Caution";
 
-const AddMemberComponent = ({ type, isOwner, item, groupID }) => {
-  let buttonDetails = {
-    text: "Remove",
-    type: "material-community",
-    icon: "account-remove",
-    backgroundColor: "red",
-    onPress: () =>
-      Caution("User will be removed from the group", () =>
-        removeUserFromGroup(groupID, item.id)
-      )
-  };
+const AddMemberComponent = ({ item, onInvite, onCancel }) => {
+  const isPendingMember = item.groupRole === "Pending Member";
+  const isNonMember = item.groupRole === "Not a Member";
 
-  switch (type) {
-    case groupMemberType.OWNER:
-      buttonDetails = null;
-      break;
-
-    case groupMemberType.ADMIN:
-      if (!isOwner) {
-        buttonDetails = null;
-      }
-      break;
-
-    case groupMemberType.PENDING_MEMBER:
-      buttonDetails = {
-        text: "Cancel",
-        type: "material-community",
-        icon: "account-cancel",
-        backgroundColor: "red",
-        onPress: () =>
-          Caution("This invitation will be removed", () =>
-            cancelGroupInvitation(groupID, item.id)
-          )
-      };
-      break;
-
-    case groupMemberType.NON_MEMBER:
-      buttonDetails = {
-        text: "Add",
-        type: "material-community",
-        icon: "account-plus",
-        backgroundColor: "green",
-        onPress: () => addUserToGroup(groupID, item.id)
-      };
-      break;
-  }
-
-  const EditButton = () =>
-    buttonDetails && (
-      <Button
-        title={buttonDetails.text}
-        icon={{
-          type: buttonDetails.type,
-          name: buttonDetails.icon,
-          color: "white"
-        }}
-        buttonStyle={[
-          styles.button,
-          { backgroundColor: buttonDetails.backgroundColor }
-        ]}
-        onPress={buttonDetails.onPress}
-      />
-    );
-
-  const groupRole =
-    type === groupMemberType.OWNER
-      ? "Owner"
-      : type === groupMemberType.ADMIN
-      ? "Admin"
-      : type === groupMemberType.MEMBER
-      ? "Member"
-      : type === groupMemberType.PENDING_MEMBER
-      ? "Pending Member"
-      : "Not A Member";
+  const EditButton = () => (
+    <ContentContainer>
+      {isPendingMember ? (
+        <Icon
+          type="material-community"
+          name="account-remove"
+          color="red"
+          size={30}
+          onPress={onCancel}
+          testID="cancelIcon"
+        />
+      ) : isNonMember ? (
+        <Icon
+          type="material-community"
+          name="account-plus"
+          color="green"
+          size={30}
+          onPress={onInvite}
+          testID="inviteIcon"
+        />
+      ) : null}
+    </ContentContainer>
+  );
 
   return (
-    <ListItem.Swipeable bottomDivider rightContent={<EditButton />}>
-      <>
-        <ContactImage item={item} />
-        <ListItem.Content>
-          <ListItem.Title>{item.username}</ListItem.Title>
-          <ListItem.Subtitle>{item.bio}</ListItem.Subtitle>
-          <ListItem.Subtitle>{groupRole}</ListItem.Subtitle>
-        </ListItem.Content>
-        <ListItem.Chevron />
-      </>
-    </ListItem.Swipeable>
+    <ListItem bottomDivider>
+      <ItemContainer>
+        <ContentContainer>
+          <ContactImage item={item} />
+        </ContentContainer>
+        <ContentContainer size="2">
+          <ListItem.Content>
+            <ListItem.Title testID="name">{item.username}</ListItem.Title>
+            <ListItem.Subtitle testID="bio">{item.bio}</ListItem.Subtitle>
+            <ListItem.Subtitle testID="role">
+              {item.groupRole}
+            </ListItem.Subtitle>
+          </ListItem.Content>
+        </ContentContainer>
+        <EditButton />
+      </ItemContainer>
+    </ListItem>
   );
 };
 
 export default AddMemberComponent;
 
-const styles = StyleSheet.create({
-  button: {
-    minHeight: "100%"
-  }
-});
+const ItemContainer = styled.View`
+  flex-direction: row;
+  margin-horizontal: 5px;
+  align-items: center;
+`;
+
+const ContentContainer = styled.View`
+  flex-direction: column;
+  flex: ${(props) => (props.size ? props.size : "1")};
+`;

--- a/src/screens/Friend/EditGroupMemberScreen.js
+++ b/src/screens/Friend/EditGroupMemberScreen.js
@@ -10,12 +10,14 @@ import {
 } from "../../styles/GeneralStyles";
 import EditMemberComponent from "../../components/Friend/EditMemberComponent";
 import { groupMemberSorter } from "../../services/Friend/Sorter";
+import { getAdvancedGroupRole } from "../../services/Friend/GroupRole";
 
 const EditGroupMemberScreen = ({ navigation, route }) => {
   const [members, setMembers] = useState([]);
   const [adminIDs, setAdminIDs] = useState([]);
   const [search, setSearch] = useState("");
   const groupInfo = route.params.groupInfo;
+  const memberIDs = members.map((user) => user.id);
 
   useEffect(() => {
     return fetchGroupMembers({
@@ -41,16 +43,16 @@ const EditGroupMemberScreen = ({ navigation, route }) => {
   }
 
   const filteredMembers = members
-    .map((member) => {
-      return {
-        ...member,
-        groupRole: isOwner(member.id)
-          ? "Owner"
-          : isAdmin(member.id)
-          ? "Admin"
-          : "Member"
-      };
-    })
+    .map((member) => ({
+      ...member,
+      groupRole: getAdvancedGroupRole(
+        member.id,
+        groupInfo.owner,
+        adminIDs,
+        memberIDs,
+        []
+      )
+    }))
     .sort(groupMemberSorter)
     .filter((member) =>
       member.username.toLowerCase().startsWith(search.toLowerCase())
@@ -73,13 +75,9 @@ const EditGroupMemberScreen = ({ navigation, route }) => {
       {filteredMembers.map((item, index) => (
         <EditMemberComponent
           key={index}
-          item={{
-            ...item,
-            isAdmin: isAdmin(item.id),
-            isOwner: isOwner(item.id)
-          }}
+          item={item}
           isMember={true}
-          groupInfo={{ ...groupInfo, admins: adminIDs }}
+          groupInfo={groupInfo}
         />
       ))}
     </ScrollContainer>

--- a/src/screens/Friend/GroupInfoScreen.js
+++ b/src/screens/Friend/GroupInfoScreen.js
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from "react";
 import { Alert } from "react-native";
-import { firebase } from "../../services/Firebase/Config";
 import {
   fetchGroupMembers,
   fetchPendingGroupMembers
@@ -8,6 +7,8 @@ import {
 import { fetchGroupAdminIDs } from "../../services/Friend/FetchGroupAdmin";
 import { groupMemberType } from "../../constants/Group";
 import { groupMemberSorter } from "../../services/Friend/Sorter";
+import { getCurrentUID } from "../../services/Profile/FetchUserInfo";
+import { getAdvancedGroupRole } from "../../services/Friend/GroupRole";
 import RenderGroupDetail from "../../components/Friend/RenderGroupDetail";
 
 const GroupInfoScreen = ({ navigation, route }) => {
@@ -15,33 +16,27 @@ const GroupInfoScreen = ({ navigation, route }) => {
   const [pendingMembers, setPendingMembers] = useState([]);
   const [adminIDs, setAdminIDs] = useState([]);
   const groupInfo = route.params.groupData;
-  const currentID = firebase.auth().currentUser.uid;
+  const currentID = getCurrentUID();
+  const memberIDs = members.map((user) => user.id);
+  const pendingMemberIDs = pendingMembers.map((user) => user.id);
 
-  function isOwner(id) {
-    return id === groupInfo.owner;
-  }
-
-  function isAdmin(id) {
-    return adminIDs.includes(id);
-  }
-
-  const renderType = isOwner(currentID)
-    ? groupMemberType.OWNER
-    : isAdmin(currentID)
-    ? groupMemberType.ADMIN
+  const renderType = adminIDs.includes(currentID)
+    ? currentID === groupInfo.owner
+      ? groupMemberType.OWNER
+      : groupMemberType.ADMIN
     : groupMemberType.MEMBER;
 
   const detailedMembers = members
-    .map((member) => {
-      return {
-        ...member,
-        groupRole: isOwner(member.id)
-          ? "Owner"
-          : isAdmin(member.id)
-          ? "Admin"
-          : "Member"
-      };
-    })
+    .map((member) => ({
+      ...member,
+      groupRole: getAdvancedGroupRole(
+        member.id,
+        groupInfo.owner,
+        adminIDs,
+        memberIDs,
+        pendingMemberIDs
+      )
+    }))
     .sort(groupMemberSorter);
 
   console.log(detailedMembers);
@@ -72,7 +67,7 @@ const GroupInfoScreen = ({ navigation, route }) => {
   return (
     <RenderGroupDetail
       type={renderType}
-      groupInfo={{ ...groupInfo, admins: adminIDs }}
+      groupInfo={groupInfo}
       members={detailedMembers}
       pendingMembers={pendingMembers}
       navigation={navigation}

--- a/src/services/Friend/GroupRole.js
+++ b/src/services/Friend/GroupRole.js
@@ -1,0 +1,38 @@
+// return user's advanced group role
+// (owner, admin, member, pending member, or non-member)
+export function getAdvancedGroupRole(
+  userID,
+  groupOwnerID,
+  groupAdmins,
+  groupMembers,
+  groupPendingMembers
+) {
+  if (groupAdmins.includes(userID)) {
+    if (userID === groupOwnerID) {
+      return "Owner";
+    } else {
+      return "Admin";
+    }
+  } else if (groupMembers.includes(userID)) {
+    return "Member";
+  } else if (groupPendingMembers.includes(userID)) {
+    return "Pending Member";
+  } else {
+    return "Not a Member";
+  }
+}
+
+// return user's simplified group role (member, pending member, or non-member)
+export function getSimplifiedGroupRole(
+  userID,
+  groupMembers,
+  groupPendingMembers
+) {
+  return getAdvancedGroupRole(
+    userID,
+    "",
+    [],
+    groupMembers,
+    groupPendingMembers
+  );
+}

--- a/src/services/Friend/Sorter.js
+++ b/src/services/Friend/Sorter.js
@@ -1,5 +1,27 @@
 export const groupMemberSorter = (x, y) => {
-  const groupRoles = ["Owner", "Admin", "Member"];
+  const groupRoles = [
+    "Owner",
+    "Admin",
+    "Member",
+    "Pending Member",
+    "Not a Member"
+  ];
+
+  if (x.groupRole === y.groupRole) {
+    return x.username - y.username;
+  }
+
+  return groupRoles.indexOf(x.groupRole) - groupRoles.indexOf(y.groupRole);
+};
+
+export const reversedGroupMemberSorter = (x, y) => {
+  const groupRoles = [
+    "Not a Member",
+    "Pending Member",
+    "Member",
+    "Admin",
+    "Owner"
+  ];
 
   if (x.groupRole === y.groupRole) {
     return x.username - y.username;


### PR DESCRIPTION
In Add Group Member screen,
- Fix bug where former group's owner can't be invited to the group again
- Primarily used to invite and cancel an invitation (similar to other messenger apps)
- Also add UI test for this screen